### PR TITLE
Add physics examples for Ammo & Cannon drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Note: if your objects are not all in the same Frame of Reference as each other (
 
 [Raycasting](https://diarmidmackenzie.github.io/instanced-mesh/tests/raycasting.html)
 
+[Physics w/ Ammo Driver](https://diarmidmackenzie.github.io/instanced-mesh/tests/physics-ammo.html)
+
+[Physics w/ Cannon Driver](https://diarmidmackenzie.github.io/instanced-mesh/tests/physics-cannon.html)
+
 ## Interface
 
 ### instanced-mesh
@@ -292,6 +296,8 @@ Typical uses for this are:
 
 - For raycasting.  Since raycasting works against invisible objects, when `memberMesh` is configured on an instanced mesh member, it can be raycasted against just like any other element.
 - For physics body configuration.  Physics engines like [aframe-physics-system](https://github.com/c-frame/aframe-physics-system) and [physx](https://github.com/c-frame/physx) typically derive physics body shapes automatically from an entity's mesh.  When using instancing, this same functionality can be made available by configuring `memberMesh` on an instanced mesh member.
+  - Note: this function is not yet working for PhysX, and has some caveats for Cannon.  See [issue #15](https://github.com/diarmidmackenzie/instanced-mesh/issues/15) for details.
+
 
 [THREE.js InstancedMesh](https://threejs.org/docs/#api/en/objects/InstancedMesh) does support raycasting directly against the instanced mesh.  That functionality is not used by this implementation for several reasons:
 

--- a/src/instanced-mesh.js
+++ b/src/instanced-mesh.js
@@ -331,6 +331,10 @@ AFRAME.registerComponent('instanced-mesh', {
       return;
     }
 
+    if (this.debug) {
+      console.log(`Member ${event.detail.member.id} to be added`);
+    }
+
     const member = event.detail.member;
     var index;
 
@@ -340,8 +344,8 @@ AFRAME.registerComponent('instanced-mesh', {
     if (this.membersToRemove.length > 0) {
 
       // Grab the index, and remove this index from the list of pending deletions.
-      const member = this.membersToRemove[0];
-      index = this.orderedMembersList.findIndex(x => (x == member));
+      const memberToRemove = this.membersToRemove[0];
+      index = this.orderedMembersList.findIndex(x => (x == memberToRemove));
 
       this.membersToRemove.splice(0, 1);
       this.orderedMembersList[index] = member;
@@ -388,7 +392,8 @@ AFRAME.registerComponent('instanced-mesh', {
       matrix = this.matrixFromMemberObjectManual(object3D);
     }
 
-    const debug = this.debug;
+    // don't output console logs for matrix updates in auto mode - too verbose.
+    const debug = (this.debug && this.data.updateMode !== "auto")
     const componentMatrix = this.componentMatrix;
     this.instancedMeshes.forEach((mesh, componentIndex) => {
 
@@ -478,6 +483,9 @@ AFRAME.registerComponent('instanced-mesh', {
   },
 
   memberRemoved: function(event) {
+    if (this.debug) {
+      console.log(`Member ${event.detail.member.id} to be removed`);
+    }
 
     if (!this.meshLoaded) {
       // Mesh not yet loaded, so instanced mesh not yet created.

--- a/tests/components/pinboard.js
+++ b/tests/components/pinboard.js
@@ -47,8 +47,7 @@ AFRAME.registerComponent('pinboard', {
         pin.setAttribute('instanced-mesh-member', 'mesh: #pin-mesh; memberMesh: true')
         if (this.data.physics === "ammo") {
           pin.setAttribute('ammo-body', 'type:static')
-          // fit: auto not working yet...
-          pin.setAttribute('ammo-shape', 'type:box; fit:manual; halfExtents: 0.05 0.5 0.05')
+          pin.setAttribute('ammo-shape', 'type:box; fit:all')
         }
         else if (this.data.physics === "cannon") {
           pin.setAttribute('static-body', '')

--- a/tests/components/pinboard.js
+++ b/tests/components/pinboard.js
@@ -1,0 +1,160 @@
+// creates a pinboard height x width, + 2m at top & bottom, laid flat.
+AFRAME.registerComponent('pinboard', {
+
+  schema: {
+      physics: {type: 'string'}, // physx , ammo or cannon
+      width: {type: 'number', default: 10},
+      height: {type: 'number', default: 10},
+  },
+
+  init() {
+
+      const width = this.data.width;
+      const height = this.data.height;
+
+      const createBox = (width, height, depth, x, y, z, color, yRot) => {
+          const box = document.createElement('a-box');
+          box.setAttribute('width', width)
+          box.setAttribute('height', height)
+          box.setAttribute('depth', depth)
+          box.setAttribute('color', color)
+          if (this.data.physics === "ammo") {
+            box.setAttribute('ammo-body', 'type:static')
+            box.setAttribute('ammo-shape', 'type:box;fit:all')
+          }
+          else if (this.data.physics === "cannon") {
+              box.setAttribute('static-body', '')
+          }
+          else {
+              box.setAttribute('physx-body', 'type:static')
+          }  
+          box.object3D.position.set(x, y, z)
+          box.object3D.rotation.set(0, yRot, 0)
+          this.el.appendChild(box)
+
+          return box
+      }
+
+      const createPin = (x, y, z, yRot) => {
+        const pin = document.createElement('a-entity');
+        pin.id = Math.random().toString(36).substring(2)
+        pin.setAttribute('instanced-mesh-member', 'mesh: #pin-mesh; memberMesh: true')
+        if (this.data.physics === "ammo") {
+          pin.setAttribute('ammo-body', 'type:static')
+          pin.setAttribute('ammo-shape', 'type:box;fit:all')
+        }
+        else if (this.data.physics === "cannon") {
+          pin.setAttribute('static-body', '')
+        }
+        else {
+          pin.setAttribute('physx-body', 'type:static')
+        }
+        pin.object3D.position.set(x, y, z)
+        pin.object3D.rotation.set(0, yRot, 0)
+        this.el.appendChild(pin)
+
+        return pin
+      }
+      
+
+      this.base = createBox(width, 1, height + 4, 0, -0.5, 0, 'grey', 0)
+      createBox(0.1, 2, height + 4, width / 2 + 0.05, 0, 0, 'grey', 0)
+      createBox(0.1, 2, height + 4, -width / 2 - 0.05, 0, 0, 'grey', 0)
+
+      for (let ii = 0; ii < this.data.height; ii++) {
+          const even = ii % 2
+          for (let jj = 0; jj < this.data.width - 1; jj++) {
+
+              createPin(jj - width / 2  + even / 2 + 0.75,
+                        0.5,
+                        ii - height / 2 + 0.5,
+                        'black',
+                        Math.PI / 4)
+          }
+      }
+  }
+})
+
+AFRAME.registerComponent('dynamic-ball', {
+
+  schema: {
+      physics: {type: 'string'}, // physx or ammo.
+      yKill: {type: 'number', default: -10}
+  },
+
+  init() {
+      const el = this.el
+      el.setAttribute('instanced-mesh-member', 'mesh:#ball-mesh; memberMesh: true')
+
+      if (this.data.physics === "ammo") {
+        el.setAttribute('ammo-body', 'type:dynamic')
+        // Explicitly specifying a shape is more efficient than auto-fitting.
+        el.setAttribute('ammo-shape', 'type:sphere; fit:manual; sphereRadius: 0.3')
+    }
+    else if (this.data.physics === "cannon") {
+        // necessary to explicitly specify sphere radius, as async call to 
+        // set radius attribute on el may not have completed yet, and Cannon uses
+        // the default radius of 1.
+        // This is seen when recycling balls (deleting and recreating them).
+        el.setAttribute('dynamic-body', 'shape: sphere; sphereRadius: 0.3')
+    }
+    else {
+        el.setAttribute('physx-body', 'type:dynamic')
+    }
+  },
+
+  tick() {
+      if (this.el.object3D.position.y < this.data.yKill) {
+          this.el.emit("recycle")
+      }
+  }
+})
+
+AFRAME.registerComponent('ball-recycler', {
+
+  schema: {
+      physics: {type: 'string'}, // physx, ammo or cannon.
+      ballCount: {type: 'number', default: 10},
+      width: {type: 'number', default: 8}, // width of spawn field
+      depth: {type: 'number', default: 8}, // depth of spawn field (after initial spawn balls always spawned at far depth)
+      yKill: {type: 'number', default: -10}
+  },
+
+  init() {
+
+      this.recycleBall = this.recycleBall.bind(this);
+
+      // at start of day, spawn balls 
+      for (let ii = 0; ii < this.data.ballCount; ii++) {
+
+          this.createBall(false)
+      }
+  },
+
+  createBall(recycled) {
+
+      const { height, depth, width } = this.data
+      const pos = this.el.object3D.position
+
+      const ball = document.createElement('a-sphere')
+          
+      ball.setAttribute('dynamic-ball', {yKill: this.data.yKill,
+                                         physics: this.data.physics})
+      x = pos.x + Math.random() * width - width / 2
+      z = recycled ? (pos.z -depth / 2) : (pos.z + Math.random() * depth - depth / 2)
+      ball.object3D.position.set(x, pos.y, z)
+      this.el.sceneEl.appendChild(ball)
+
+      ball.addEventListener('recycle', this.recycleBall);
+
+  },
+
+  recycleBall(evt) {
+
+      const ball = evt.target
+
+      ball.parentNode.removeChild(ball);
+      this.createBall(true)
+
+  }
+})

--- a/tests/components/pinboard.js
+++ b/tests/components/pinboard.js
@@ -1,3 +1,5 @@
+ballCounter = 0;
+
 // creates a pinboard height x width, + 2m at top & bottom, laid flat.
 AFRAME.registerComponent('pinboard', {
 
@@ -38,10 +40,11 @@ AFRAME.registerComponent('pinboard', {
       const createPin = (x, y, z, yRot) => {
         const pin = document.createElement('a-entity');
         pin.id = Math.random().toString(36).substring(2)
-        pin.setAttribute('instanced-mesh-member', 'mesh: #pin-mesh; memberMesh: true')
+        pin.setAttribute('instanced-mesh-member', 'mesh: #pin-mesh')
         if (this.data.physics === "ammo") {
           pin.setAttribute('ammo-body', 'type:static')
-          pin.setAttribute('ammo-shape', 'type:box;fit:all')
+          // fit: auto not working yet...
+          pin.setAttribute('ammo-shape', 'type:box; fit:manual; halfExtents: 0.05 0.5 0.05')
         }
         else if (this.data.physics === "cannon") {
           pin.setAttribute('static-body', '')
@@ -55,7 +58,6 @@ AFRAME.registerComponent('pinboard', {
 
         return pin
       }
-      
 
       this.base = createBox(width, 1, height + 4, 0, -0.5, 0, 'grey', 0)
       createBox(0.1, 2, height + 4, width / 2 + 0.05, 0, 0, 'grey', 0)
@@ -68,7 +70,6 @@ AFRAME.registerComponent('pinboard', {
               createPin(jj - width / 2  + even / 2 + 0.75,
                         0.5,
                         ii - height / 2 + 0.5,
-                        'black',
                         Math.PI / 4)
           }
       }
@@ -136,7 +137,9 @@ AFRAME.registerComponent('ball-recycler', {
       const { height, depth, width } = this.data
       const pos = this.el.object3D.position
 
-      const ball = document.createElement('a-sphere')
+      const ball = document.createElement('a-entity')
+      ball.id = `ball-${ballCounter}`
+      ballCounter++
           
       ball.setAttribute('dynamic-ball', {yKill: this.data.yKill,
                                          physics: this.data.physics})

--- a/tests/components/pinboard.js
+++ b/tests/components/pinboard.js
@@ -47,8 +47,7 @@ AFRAME.registerComponent('pinboard', {
           pin.setAttribute('ammo-shape', 'type:box; fit:manual; halfExtents: 0.05 0.5 0.05')
         }
         else if (this.data.physics === "cannon") {
-          // shape: auto not working yet...
-          pin.setAttribute('static-body', 'shape: box; halfExtents: 0.05 0.5 0.05')
+          pin.setAttribute('static-body', '')
         }
         else {
           pin.setAttribute('physx-body', 'type:static')

--- a/tests/components/pinboard.js
+++ b/tests/components/pinboard.js
@@ -1,3 +1,7 @@
+/* Components in this modeule are derived from:
+ * https://github.com/c-frame/aframe-physics-system/blob/master/examples/components/pinboard.js
+ */
+
 ballCounter = 0;
 
 // creates a pinboard height x width, + 2m at top & bottom, laid flat.
@@ -25,10 +29,10 @@ AFRAME.registerComponent('pinboard', {
             box.setAttribute('ammo-shape', 'type:box;fit:all')
           }
           else if (this.data.physics === "cannon") {
-              box.setAttribute('static-body', '')
+            box.setAttribute('static-body', '')
           }
           else {
-              box.setAttribute('physx-body', 'type:static')
+            box.setAttribute('physx-body', 'type:static')
           }  
           box.object3D.position.set(x, y, z)
           box.object3D.rotation.set(0, yRot, 0)

--- a/tests/components/pinboard.js
+++ b/tests/components/pinboard.js
@@ -40,14 +40,15 @@ AFRAME.registerComponent('pinboard', {
       const createPin = (x, y, z, yRot) => {
         const pin = document.createElement('a-entity');
         pin.id = Math.random().toString(36).substring(2)
-        pin.setAttribute('instanced-mesh-member', 'mesh: #pin-mesh')
+        pin.setAttribute('instanced-mesh-member', 'mesh: #pin-mesh; memberMesh: true')
         if (this.data.physics === "ammo") {
           pin.setAttribute('ammo-body', 'type:static')
           // fit: auto not working yet...
           pin.setAttribute('ammo-shape', 'type:box; fit:manual; halfExtents: 0.05 0.5 0.05')
         }
         else if (this.data.physics === "cannon") {
-          pin.setAttribute('static-body', '')
+          // shape: auto not working yet...
+          pin.setAttribute('static-body', 'shape: box; halfExtents: 0.05 0.5 0.05')
         }
         else {
           pin.setAttribute('physx-body', 'type:static')

--- a/tests/physics-ammo.html
+++ b/tests/physics-ammo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Physics Benchmark Test - PhysX</title>
+    <meta name="description" content="Physics Benchmark Test - PhysX">
+    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    <script src="https://mixedreality.mozilla.org/ammo.js/builds/ammo.wasm.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-physics-system@v4.1.0/dist/aframe-physics-system.min.js"></script>
+    <script src="./components/pinboard.js"></script>
+    <script src="../src/instanced-mesh.js"></script>
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <a class="code-link"
+      target="_blank"
+      href="https://github.com/diarmidmackenzie/instanced-mesh/tests/physics-ammo.html">
+      view code
+    </a>
+    <a-scene physics="driver: ammo; stats: panel"
+             stats>
+        <a-box id="pin-mesh" color="black" width="0.1" depth="0.1" height="1"
+               instanced-mesh="capacity: 500; position:world"></a-box>
+        <a-sphere id="ball-mesh" radius="0.3" color="yellow"
+               instanced-mesh="capacity: 100; position:world; updateMode: auto"></a-sphere>
+        <a-entity id="pinboard" pinboard="physics: physx; height:20; width: 20" position = "0 0 -20" rotation = "45 0 0">
+        </a-entity>
+
+        <a-entity id="ball-recycler" ball-recycler="physics: physx; ballCount: 100; width: 15; depth: 15; yKill: -8" position="0 8 -20">
+        </a-entity>
+    </a-scene>
+  </body>
+</html>
+
+   
+   

--- a/tests/physics-ammo.html
+++ b/tests/physics-ammo.html
@@ -6,7 +6,7 @@
     <meta name="description" content="Physics Benchmark Test - PhysX">
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://mixedreality.mozilla.org/ammo.js/builds/ammo.wasm.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-physics-system@v4.1.0/dist/aframe-physics-system.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-physics-system@master/dist/aframe-physics-system.min.js"></script>
     <script src="./components/pinboard.js"></script>
     <script src="../src/instanced-mesh.js"></script>
     <link rel="stylesheet" href="./styles.css">
@@ -17,9 +17,9 @@
       href="https://github.com/diarmidmackenzie/instanced-mesh/tests/physics-ammo.html">
       view code
     </a>
-    <a-scene physics="driver: ammo"
+    <a-scene physics="driver: ammo; stats: panel"
              stats>
-             
+
         <a-entity id="pinboard" pinboard="physics: ammo; height:20; width: 20" position = "0 0 -20" rotation = "45 0 0">  
           <a-box id="pin-mesh" color="black" width="0.1" depth="0.1" height="1"
                instanced-mesh="capacity: 500"></a-box>

--- a/tests/physics-ammo.html
+++ b/tests/physics-ammo.html
@@ -17,16 +17,17 @@
       href="https://github.com/diarmidmackenzie/instanced-mesh/tests/physics-ammo.html">
       view code
     </a>
-    <a-scene physics="driver: ammo; stats: panel"
+    <a-scene physics="driver: ammo"
              stats>
-        <a-box id="pin-mesh" color="black" width="0.1" depth="0.1" height="1"
-               instanced-mesh="capacity: 500; position:world"></a-box>
-        <a-sphere id="ball-mesh" radius="0.3" color="yellow"
-               instanced-mesh="capacity: 100; position:world; updateMode: auto"></a-sphere>
-        <a-entity id="pinboard" pinboard="physics: physx; height:20; width: 20" position = "0 0 -20" rotation = "45 0 0">
+             
+        <a-entity id="pinboard" pinboard="physics: ammo; height:20; width: 20" position = "0 0 -20" rotation = "45 0 0">  
+          <a-box id="pin-mesh" color="black" width="0.1" depth="0.1" height="1"
+               instanced-mesh="capacity: 500"></a-box>
         </a-entity>
 
-        <a-entity id="ball-recycler" ball-recycler="physics: physx; ballCount: 100; width: 15; depth: 15; yKill: -8" position="0 8 -20">
+        <a-sphere id="ball-mesh" radius="0.3" color="yellow"
+               instanced-mesh="capacity: 100; updateMode: auto"></a-sphere>
+        <a-entity id="ball-recycler" ball-recycler="physics: ammo; ballCount: 100; width: 15; depth: 15; yKill: -8" position="0 8 -20">
         </a-entity>
     </a-scene>
   </body>

--- a/tests/physics-ammo.html
+++ b/tests/physics-ammo.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Physics Benchmark Test - PhysX</title>
-    <meta name="description" content="Physics Benchmark Test - PhysX">
+    <title>Physics Benchmark Test - Ammo</title>
+    <meta name="description" content="Physics Benchmark Test - Ammo">
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://mixedreality.mozilla.org/ammo.js/builds/ammo.wasm.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-physics-system@master/dist/aframe-physics-system.min.js"></script>

--- a/tests/physics-cannon.html
+++ b/tests/physics-cannon.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Physics Benchmark Test - Cannon</title>
+    <meta name="description" content="Physics Benchmark Test - Cannon">
+    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-physics-system@master/dist/aframe-physics-system.js"></script>
+    <script src="./components/pinboard.js"></script>
+    <script src="../src/instanced-mesh.js"></script>
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <a class="code-link"
+      target="_blank"
+      href="https://github.com/diarmidmackenzie/instanced-mesh/tests/physics-cannon.html">
+      view code
+    </a>
+    <a-scene physics="restitution: 0; stats: panel"
+             stats>
+
+        <a-entity id="pinboard" pinboard="physics: cannon; height:20; width: 20" position = "0 0 -20" rotation = "45 0 0">  
+          <a-box id="pin-mesh" color="black" width="0.1" depth="0.1" height="1"
+               instanced-mesh="capacity: 500"></a-box>
+        </a-entity>
+
+        <a-sphere id="ball-mesh" radius="0.3" color="yellow"
+               instanced-mesh="capacity: 100; updateMode: auto"></a-sphere>
+        <a-entity id="ball-recycler" ball-recycler="physics: cannon; ballCount: 100; width: 15; depth: 15; yKill: -8" position="0 8 -20">
+        </a-entity>
+    </a-scene>
+  </body>
+</html>

--- a/tests/physics-cannon.html
+++ b/tests/physics-cannon.html
@@ -5,7 +5,7 @@
     <title>Physics Benchmark Test - Cannon</title>
     <meta name="description" content="Physics Benchmark Test - Cannon">
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-physics-system@master/dist/aframe-physics-system.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-physics-system@master/dist/aframe-physics-system.min.js"></script>
     <script src="./components/pinboard.js"></script>
     <script src="../src/instanced-mesh.js"></script>
     <link rel="stylesheet" href="./styles.css">

--- a/tests/spheres.html
+++ b/tests/spheres.html
@@ -16,10 +16,9 @@
        value="A selection of red speres,
        all different sizes."></a-text>
 
-    <a-entity id="mesh1"
-              geometry= "primitive: sphere"
+    <a-sphere id="mesh1"
               material="color:red"
-              instanced-mesh></a-entity>
+              instanced-mesh></a-sphere>
 
     <a-entity id ="sphere0" position = "-4 4 -6" scale="2 2 2" instanced-mesh-member="mesh:#mesh1"></a-entity>
     <a-entity id ="sphere1" position = "-2 -2 -8" scale="3 3 3" instanced-mesh-member="mesh:#mesh1"></a-entity>

--- a/tests/styles.css
+++ b/tests/styles.css
@@ -1,0 +1,39 @@
+
+.code-link {
+    position: fixed;
+    right: 50px;
+    top: 50px;
+    width: 70px;
+    height: 70px;
+    border-radius: 50%;
+    display: flex;
+    background: white;
+    justify-content: center;
+    align-items: center;
+    font-size: 20px;
+    text-decoration: none;
+    text-align: center;
+    color: black;
+    font-family: courier;
+    font-weight: bold;
+    z-index: 10;
+}
+
+.text-overlay {
+  background: black;
+  color: white;
+  width: 40%;
+  position: absolute;
+  bottom: 10px;
+  left: 30%;
+  z-index: 10;
+  font-size: 20px;
+  font-family: arial;
+  display: flex;
+  flex-direction: column;
+  align-items: left;
+}
+
+.text-overlay p {
+margin: 0.2em 1em;
+}


### PR DESCRIPTION
PhysX needs some more work, probably inside the PhysX repo, so not publishing that example for now (it doesn't work at all).