### PR TITLE
Fix for performance issue with empty instanced mesh

### DIFF
--- a/src/instanced-mesh.js
+++ b/src/instanced-mesh.js
@@ -184,13 +184,16 @@ AFRAME.registerComponent('instanced-mesh', {
       this.componentOriginalColors = [];
 
       this.meshNodes.forEach((node, index) => {
-        var instancedMesh = new THREE.InstancedMesh(node.geometry,
-                                                    node.material,
-                                                    this.data.capacity);
+        const instancedMesh = new THREE.InstancedMesh(node.geometry,
+                                                      node.material,
+                                                      this.data.capacity);
+        // mesh doesn't have any members yet
+        instancedMesh.count = 0
 
         // For each instanced mesh required, we store off both the instanced mesh
         // itself. and the transform matrix for the component of the model that
         // it represents.
+        
         this.instancedMeshes.push(instancedMesh)
         this.componentMatrices.push(node.matrixWorld)
         this.componentMaterialIndices.push(node.materialIndex)

--- a/tests/empty-instanced-mesh.html
+++ b/tests/empty-instanced-mesh.html
@@ -1,0 +1,30 @@
+<html>
+  <head>
+    <script src="https://aframe.io/releases/1.4.0/aframe.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@c5c5dcf/dist/aframe-extras.min.js"></script>
+    <script src="../src/instanced-mesh.js"></script>
+    <script src="./framed-block.js"></script>
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <div class="text-overlay">
+      <p>Empty instanced mesh.</p>
+      <p>No objects should be visible, amd draw calls should be zero.</p>
+    </div>
+    <a class="code-link"
+      target="_blank"
+      href="https://github.com/diarmidmackenzie/instanced-mesh/blob/main/tests/empty-instanced-mesh.html">
+      view code
+    </a>
+    <a-scene stats renderer="colorManagement:true">
+
+      <a-entity id="rig" movement-controls>
+        <a-entity id="camera" camera position="0 1.6 3" look-controls>
+        </a-entity>
+      </a-entity>
+
+      <a-entity id="mesh1" framed-block="facecolor: white; framecolor: black" instanced-mesh="capacity:500"></a-entity>
+
+</a-scene>
+
+</body>


### PR DESCRIPTION
Following upgrade to A-Frame 1.4.0+ I have seen performance issues with applications using aframe-instanced-mesh.

Tracked this down to a problem with initial mesh creation.  The count for the members was not set until the first member was added, so if an instanced mesh was created, but no members added yet, instances were rendered for every entry in the entire (uninitialized) instance matrix, up to whatever capacity the instanced mesh had.

This has been seen to cause severe performance issues for A-Frame 1.4.0+.

For earlier versions of A-Frame (1.3.0 and below) there doesn't seem to have been a problem, though I haven't understood why not.

Fix includes a new test page: `empty-instanced-mesh.html` which can be used to test this case.