### PR TITLE
Declare meshNodes variable in constructMeshNodes

### DIFF
--- a/src/instanced-mesh.js
+++ b/src/instanced-mesh.js
@@ -353,7 +353,7 @@ AFRAME.registerComponent('instanced-mesh', {
   // - material(s) of each component
   // - transforms of each component.
   constructMeshNodes: function(originalMesh) {
-    meshNodes  = [];
+    const meshNodes = [];
 
     originalMesh.updateMatrixWorld()
     this.inverseMatrix.copy(originalMesh.matrixWorld)


### PR DESCRIPTION
I recently switched my webpack project to "type": "module" in package.json with a local copy of instanced-mesh.js, it really doesn't like undeclared variable in this mode and you find out at runtime the issue. Not sure why it didn't complain before, but here is a fix.