### PR TITLE
Fix npm usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-export { default } from './instanced-mesh.js';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aframe-instanced-mesh",
   "version": "0.7.3",
   "description": "Use three.js InstancedMesh object within A-Frame",
-  "main": "index.js",
+  "main": "src/instanced-mesh.js",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
The `index.js` referenced `./instanced-mesh.js` instead of `./src/instanced-mesh.js` so using the package with npm didn't work. I removed the `index.js` and exposed directly `./src/instanced-mesh.js` in `package.json`

This fixes #47